### PR TITLE
Change root node name to documentation, not documetation

### DIFF
--- a/lib/templates/default/fulldoc/xml/setup.rb
+++ b/lib/templates/default/fulldoc/xml/setup.rb
@@ -19,7 +19,7 @@
 def init
   Templates::Engine.with_serializer('index.xml', options[:serializer]) do
     xml = Builder::XmlMarkup.new(:indent => 4)
-    xml.documetation do
+    xml.documentation do
       YARD::Registry.root.children.sort_by do |child|
         [
           child.type.to_s,


### PR DESCRIPTION
The root node name is misspelt in the fulldoc template.
